### PR TITLE
Removed unnecesary "cd"

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ Then you can copy the extension to your test server and remove it from the local
 To load the extension into Zimbra you have to restart Zimbra's mailbox process:
 
       su - zimbra
-      cd ~
       zmmailboxdctl restart
       
 Monitor the log files while developing and deploying extensions. The relevant log files are:


### PR DESCRIPTION
As in the line 178 indicates "su - zimbra", the user has already been in the home directory, and the "cd ~" is not necessary.  Besides, all the Zimbra's documents don't mention "cd ~" before restarting the mailbox (For example, please refer to the
https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0/P28 and search for the "zmmailboxdctl restart")

Note: According to the "man su", the "-" option means "Provide an environment similar to what the user would expect had the user logged in directly."